### PR TITLE
Fix kubernetes plugin path.

### DIFF
--- a/modules/dynamic-plugins/rhdh-supported-plugins.adoc
+++ b/modules/dynamic-plugins/rhdh-supported-plugins.adoc
@@ -278,7 +278,7 @@ a|
 |Disabled
 
 |Kubernetes  |@backstage/plugin-kubernetes |Frontend |0.11.9 |Community Support
-|./dynamic-plugins/dist/backstage-plugin-kubernetes-dynamic
+|./dynamic-plugins/dist/backstage-plugin-kubernetes
 a|
 |Disabled
 


### PR DESCRIPTION
The path for the community "plugin-kubernetes" is incorrect.  It should not end with "-dynamic".

Using the path as stated in the docs causes the RHDH init container to crash as it can't find the path in the filesycem.

